### PR TITLE
Fixing "Invalid argument" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ This script must be run with root or sudo privileges. Only Celsius temperatures 
 For more instructions, see here:  
 http://seperohacker.blogspot.com/2012/10/linux-keep-your-cpu-cool-with-frequency.html
 
+## Warning!
+For normal working please add lines below to /etc/rc.local **before** "exit 0":
+
+    for I in $(find /sys/devices/system/cpu/ -maxdepth 1 -name 'cpu?' | sed 's_/sys/devices/system/cpu/cpu__g')
+    do
+	    cpufreq-set -c $I --min 800000
+    done
+
+
 
 Author: Sepero (sepero 111 @ gmx . com)
 

--- a/temp_throttle.sh
+++ b/temp_throttle.sh
@@ -104,7 +104,7 @@ set_freq () {
 	FREQ_TO_SET=$(echo $FREQ_LIST | cut -d " " -f $CURRENT_FREQ)
 	echo $FREQ_TO_SET
 	for i in $(seq 0 $CORES); do
-		echo $FREQ_TO_SET > /sys/devices/system/cpu/cpu$i/cpufreq/scaling_max_freq
+		cpufreq-set -c $i --max $FREQ_TO_SET
 	done
 }
 
@@ -128,7 +128,7 @@ unthrottle () {
 
 get_temp () {
 	# Get the system temperature.
-	
+
 	TEMP=$(cat $TEMP_FILE)
 }
 


### PR DESCRIPTION
On Ubuntu 12.04 this script not working with error ```echo: write error: Invalid argument```
These commits fixing it.