### PR TITLE
added config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ Set a maximum temperature for your system using this script. If the maximum temp
 
 This script must be run with root or sudo privileges. Only Celsius temperatures are supported. This example will limit system temperatures to 80 Celsius:
 
-    sudo ./temp_throttle.sh 80
+```
+sudo ./temp_throttle.sh 80
+```
+
+Another way to set the temperature is to use a config file which contains
+```
+MAX_TEMP=80
+```
+and is named **~/.temp_throttle.conf** or **/etc/temp_throttle.conf**
 
 
 For more instructions, see here:  
@@ -21,6 +29,3 @@ Links: http://github.com/Sepero/temp-throttle/
 Links: http://seperohacker.blogspot.com/2012/10/linux-keep-your-cpu-cool-with-frequency.html  
 
 License: GNU GPL 2.0
-
-Usage: `temp_throttle.sh max_temp`  
-USES CELSIUS TEMPERATURES  

--- a/temp_throttle.sh
+++ b/temp_throttle.sh
@@ -25,16 +25,22 @@ err_exit () {
 	exit 128
 }
 
-if [ $# -ne 1 ]; then
-	# If temperature wasn't given, then print a message and exit.
+# Load .conf
+if test -f $HOME/.temp_throttle.conf; then
+	. $HOME/.temp_throttle.conf
+elif test -f /etc/temp_throttle.conf; then
+	. /etc/temp_throttle.conf
+fi
+
+if [ $# -ne 1 ] && [ -z $MAX_TEMP ]; then
+	# If temperature wasn't given or set by .conf, then print a message and exit.
 	echo "Please supply a maximum desired temperature in Celsius." 1>&2
 	echo "For example:  ${0} 60" 1>&2
 	exit 2
-else
+elif [ $# -eq 1 ]; then
 	#Set the first argument as the maximum desired temperature.
 	MAX_TEMP=$1
 fi
-
 
 ### START Initialize Global variables.
 


### PR DESCRIPTION
Config file can be used to set the temperature. File can be named 
```
/etc/temp_throttle.conf
```
or
```
~/.temp_throttle.conf
```

Config file settings can be overridden with the usual command line argument. Settings from the users home directory override the settings from /etc.

The file must contain the line 'MAX_TEMP=whatever-temperature-you-like' - e.g.:
```
MAX_TEMP=80
```
resolve #10 